### PR TITLE
Changes to the Readme - Pradhyumnaa G

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This guide explains how to set up the local environment for grafana.
 The easiest way to get started is using the given Docker Compose file:
 
 ```bash
-docker-compose up -d
+sudo docker compose up -d
 ```
 
 This will start:
@@ -42,7 +42,7 @@ Write Access:
 
 ```bash
 # Stop all services
-docker-compose down
+sudo docker compose down
 ```
 
 # Backend for test data


### PR DESCRIPTION
All newly installed Docker and Docker Compose's commands have been slightly changed due to the versioning.

sudo docker-compose up -d will no longer work but sudo docker compose up -d will work.

Adding the sudo for Superuser as without it, we lack the permissions to get the Grafana Image.